### PR TITLE
fix read-targets bug

### DIFF
--- a/project-cmake-api.el
+++ b/project-cmake-api.el
@@ -115,10 +115,12 @@
 	artifact))
 
 (defun project-cmake-api-current-buffer-target ()
-  (let* ((file-name (expand-file-name (buffer-file-name (current-buffer))))
-		 (database (project-cmake-api-project-database)))
-	(and database
-		 (gethash file-name (project-cmake-targets-sources database) nil))))
+  (if (buffer-file-name (current-buffer))
+      (let* ((file-name (expand-file-name (buffer-file-name (current-buffer))))
+		     (database (project-cmake-api-project-database)))
+	    (and database
+		     (gethash file-name (project-cmake-targets-sources database) nil)))
+    nil))
 
 (defun project-cmake-api-choose-target ()
   "Select by name one of CMake's build targets. Returns target's name."
@@ -147,7 +149,7 @@
 (defun project-cmake-api-read-targets (reply-files)
   (let ((source-directory (project-cmake-source-directory))
 		(sources (make-hash-table :test 'equal))
-		(all-target-names '("all" "clean"))
+		(all-target-names (list "all" "clean"))
 		executables
 		libraries
 		all-targets)

--- a/project-cmake.el
+++ b/project-cmake.el
@@ -678,7 +678,7 @@ scratch, preserving the existing configuration."
   "Build a project tree using CMake and the current kit.  If
 provided an argument, it can recompile the whole project from
 scratch, preserving the existing configuration."
-  (interactive "P")
+  (interactive)
   (unless (project-cmake-ensure-configured)
 	(error "Cannot build project that has not been configured first."))
   (project-cmake-kit-compile (project-cmake-kit-install-command)))


### PR DESCRIPTION
- '() is not safe when calling the outer function many times.
  check this out: https://stackoverflow.com/a/16673364

- "expand-file-name" will complain when calling
  "project-cmake-api-current-buffer-target" in the non
  file-buffer.