### PR TITLE
project-cmake: Add dependencies for internal packages.

### DIFF
--- a/project-cmake.el
+++ b/project-cmake.el
@@ -5,7 +5,7 @@
 ;; Maintainer: Juan Jose Garcia-Ripoll <juanjose.garciaripoll@gmail.com>
 ;; URL: https://github.com/juanjosegarciaripoll/project-cmake
 ;; Keywords: convenience, languages
-;; Package-Requires: ((emacs "26.1") (project "0.3.0"))
+;; Package-Requires: ((emacs "26.1") (project "0.3.0") project-local project-cmake-api)
 
 ;; MIT License
 


### PR DESCRIPTION
I would like to contribute recipes for the packages here to MELPA. MELPA wants each package published separately, and in order for dependencies to work "project-cmake" must require the other two internal packages.